### PR TITLE
CI: Make sure pre-commit.ci creates safe subjects

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,7 @@
 ---
+ci:
+  autofix_commit_msg: "Chore: pre-commit autoupdate"
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1


### PR DESCRIPTION
When pre-commit.ci creates autoupdate PRs it by default creates a
subject line that does not conform to our standards.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
