### PR TITLE
Fix: Base action on lfreleng/sigul image and armor sign-data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,12 @@
-FROM centos:7
+# The sigul client image is built and published from the releng/sigul-docker
+# project on gerrit.linuxfoundation.org (docker.io/lfreleng/sigul). Basing this
+# action on that image keeps the CentOS 7 / sigul install logic in a single
+# place instead of duplicating it here.
+#
+# Pinned by digest for reproducibility. Human-readable tag: 0.1.0
+FROM docker.io/lfreleng/sigul@sha256:e8b958a6e5ba3ee6334c0244e9fbe0881248133e97bc77236a176baa5d219cbd
 
 LABEL maintainer="<eball@linuxfoundation.org>"
-
-SHELL ["/bin/bash", "-c"]
-
-RUN echo $'[fedora-infra-sigul] \n\
-name=Fedora builder packages for sigul \n\
-baseurl=https://kojipkgs.fedoraproject.org/repos-dist/epel\$releasever-infra/latest/\$basearch/ \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-gpgkey=https://infrastructure.fedoraproject.org/repo/infra/RPM-GPG-KEY-INFRA-TAGS \n\
-includepkgs=sigul* \n\
-skip_if_unavailable=True' > /etc/yum.repos.d/fedora-infra-sigul.repo
-
-RUN yum install -y -q sigul git
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,13 +28,13 @@ if [ "$SIGN_TYPE" = "sign-data" ]; then
                     continue
                 fi
                 echo "Signing $wcfile"
-                sigul --batch "$SIGN_TYPE" -o "$wcfile.asc" "$SIGUL_KEY_NAME" \
+                sigul --batch "$SIGN_TYPE" -a -o "$wcfile.asc" "$SIGUL_KEY_NAME" \
                     "$wcfile" < "${SIGUL_PASS_FILE}"
                 chmod 644 "$wcfile.asc"
             done
         else
             echo "Signing $filename"
-            sigul --batch "$SIGN_TYPE" -o "$filename.asc" "$SIGUL_KEY_NAME" \
+            sigul --batch "$SIGN_TYPE" -a -o "$filename.asc" "$SIGUL_KEY_NAME" \
                 "$filename" < "${SIGUL_PASS_FILE}"
             chmod 644 "$filename.asc"
         fi


### PR DESCRIPTION
## What

- **Base the action on `docker.io/lfreleng/sigul`** (pinned by digest, tag `0.1.0`) instead of building the sigul client inline from `centos:7`. That image is built and published from the `releng/sigul-docker` project on gerrit.linuxfoundation.org, so the CentOS 7 / sigul install logic lives in a **single source of truth** rather than being duplicated here.
- **Add `-a` (ASCII armor) to the `sign-data` invocations** so the produced `.asc` detached signatures are armored, which Maven Central / OSSRH requires. `sign-git-tag` is unchanged.

## Why

The inline build no longer works: CentOS 7 is EOL (June 2024) and `mirrorlist.centos.org` is offline, so the original `yum install sigul git` fails with `Cannot find a valid baseurl for repo: base/7/x86_64`.

## Validation

- `docker build` succeeds pulling the pinned image.
- The resulting container runs `sigul --version` (client 0.207).
- Proven end-to-end in the ODL GHA Maven stage/release pipeline (artifact signing).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>